### PR TITLE
Implement swipe controls for backpack

### DIFF
--- a/src/features/game/ui/BackpackControls.tsx
+++ b/src/features/game/ui/BackpackControls.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useGameModelStore } from '@/features/game/model/gameModelStore';
 import styled from 'styled-components';
 import { ForwardIcon, LeftIcon } from '@/shared/ui';
 import { useCoinAnimationStore } from '@/features/game/model/coinAnimationStore';
+import { useSwipe } from '@/hooks';
 
 export const BackpackControls = () => {
   const moveLeft = useGameModelStore((s) => s.moveLeft);
   const moveRight = useGameModelStore((s) => s.moveRight);
   const flyingCoins = useCoinAnimationStore((s) => s.flyingCoins);
-  const touchStartX = useRef<number | null>(null);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -20,25 +20,7 @@ export const BackpackControls = () => {
     return () => window.removeEventListener('keydown', handleKey);
   }, [flyingCoins.length, moveLeft, moveRight]);
 
-  useEffect(() => {
-    const handleTouchStart = (e: TouchEvent) => {
-      touchStartX.current = e.touches[0].clientX;
-    };
-    const handleTouchEnd = (e: TouchEvent) => {
-      if (touchStartX.current === null) return;
-      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
-      if (deltaX > 30) moveRight();
-      if (deltaX < -30) moveLeft();
-      touchStartX.current = null;
-    };
-
-    window.addEventListener('touchstart', handleTouchStart);
-    window.addEventListener('touchend', handleTouchEnd);
-    return () => {
-      window.removeEventListener('touchstart', handleTouchStart);
-      window.removeEventListener('touchend', handleTouchEnd);
-    };
-  }, [moveLeft, moveRight]);
+  useSwipe({ onSwipeLeft: moveLeft, onSwipeRight: moveRight });
 
   return (
     <ControlsWrapper>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useContainerSize';
+export * from './useSwipe';

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+interface UseSwipeOptions {
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  /** Minimum horizontal distance in pixels to trigger a swipe */
+  threshold?: number;
+}
+
+export const useSwipe = ({
+  onSwipeLeft,
+  onSwipeRight,
+  threshold = 30,
+}: UseSwipeOptions) => {
+  const startX = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      startX.current = e.touches[0].clientX;
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (startX.current === null) return;
+      const diff = e.changedTouches[0].clientX - startX.current;
+      if (diff > threshold) {
+        onSwipeRight?.();
+      } else if (diff < -threshold) {
+        onSwipeLeft?.();
+      }
+      startX.current = null;
+    };
+
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchend', handleTouchEnd);
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [onSwipeLeft, onSwipeRight, threshold]);
+};


### PR DESCRIPTION
## Summary
- add `useSwipe` hook
- use `useSwipe` in `BackpackControls`
- re-export new hook

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851b2e422908323a7a2b83c4529317a