### PR TITLE
Add profile screen

### DIFF
--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -22,7 +22,7 @@ export function HomeScreen() {
               745
             </Flex>
           </ZewaButton>
-          <ZewaButton variant="white">
+          <ZewaButton variant="white" onClick={() => navigate('/profile')}>
             <UserIcon />
           </ZewaButton>
         </Flex>

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -8,3 +8,4 @@ export * from './faq/FaqScreen';
 export * from './tournament/TournamentScreen';
 export * from './game';
 export * from './error/ErrorPage';
+export * from './profile/ProfileScreen';

--- a/src/features/profile/ProfileScreen.tsx
+++ b/src/features/profile/ProfileScreen.tsx
@@ -1,0 +1,20 @@
+import { PageContainer, Text } from '@/shared/ui';
+import { useUserStore } from '@/shared/model';
+
+export function ProfileScreen() {
+  const user = useUserStore((s) => s.user);
+
+  return (
+    <PageContainer title="Личный кабинет" scrollable={false}>
+      {user ? (
+        <Text size="p4" color="#fff">
+          {user.firstName || `ID: ${user.id}`}
+        </Text>
+      ) : (
+        <Text size="p4" color="#fff">
+          Пользователь не найден
+        </Text>
+      )}
+    </PageContainer>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,6 +28,9 @@ const GameRulesScreen = lazy(() =>
 const GameScreen = lazy(() =>
   import('@/features/game/GameScreen').then((m) => ({ default: m.GameScreen })),
 );
+const ProfileScreen = lazy(() =>
+  import('@/features/profile/ProfileScreen').then((m) => ({ default: m.ProfileScreen })),
+);
 
 export const router = createHashRouter([
   { path: '/', element: <HomeScreen /> },
@@ -39,4 +42,5 @@ export const router = createHashRouter([
   { path: '/tournament', element: <TournamentScreen /> },
   { path: '/game/rules', element: <GameRulesScreen /> },
   { path: '/game', element: <GameScreen /> },
+  { path: '/profile', element: <ProfileScreen /> },
 ]);


### PR DESCRIPTION
## Summary
- add profile page to display Telegram info
- link profile page from the home screen
- register profile page in router

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6851b73861c48323b5dac527b6ea8431