### PR TITLE
Fix pause modal reopening logic

### DIFF
--- a/src/features/game/lib/useHowToPlayEntry.tsx
+++ b/src/features/game/lib/useHowToPlayEntry.tsx
@@ -9,8 +9,10 @@ export function useHowToPlayEntry() {
 
   useEffect(() => {
     const cameFromRules = sessionStorage.getItem('cameFromRules') === 'true';
-    if (!cameFromRules) resetSession();
-    resetGame();
+    if (!cameFromRules) {
+      resetSession();
+      resetGame();
+    }
     sessionStorage.removeItem('cameFromRules');
   }, [resetGame, resetSession]);
 


### PR DESCRIPTION
## Summary
- update `useHowToPlayEntry` to keep game state when returning from the rules screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851ba451b488323aa6b0ec864751813