### PR TITLE
Fix GH pages asset paths

### DIFF
--- a/src/features/game/constants/items.ts
+++ b/src/features/game/constants/items.ts
@@ -44,7 +44,7 @@ export interface ItemMeta {
 }
 
 export const coinMeta = {
-  texture: '/assets/images/coin.png',
+  texture: './assets/images/coin.png',
   width: 48,
   height: 48,
   isGood: true,
@@ -53,7 +53,7 @@ export const coinMeta = {
 export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   book: {
     kind: 'book',
-    texture: '/assets/images/items/book.png',
+    texture: './assets/images/items/book.png',
     radius: 1,
     scale: 1,
     width: 92,
@@ -62,7 +62,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   palette: {
     kind: 'palette',
-    texture: '/assets/images/items/palette.png',
+    texture: './assets/images/items/palette.png',
     radius: 1,
     scale: 1,
     width: 80,
@@ -71,7 +71,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   marker: {
     kind: 'marker',
-    texture: '/assets/images/items/marker.png',
+    texture: './assets/images/items/marker.png',
     radius: 1,
     scale: 1,
     width: 68,
@@ -80,7 +80,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   apple: {
     kind: 'apple',
-    texture: '/assets/images/items/apple.png',
+    texture: './assets/images/items/apple.png',
     radius: 1,
     scale: 1,
     width: 54,
@@ -89,7 +89,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   scissors: {
     kind: 'scissors',
-    texture: '/assets/images/items/scissors.png',
+    texture: './assets/images/items/scissors.png',
     radius: 1,
     scale: 1,
     width: 82,
@@ -98,7 +98,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   pen: {
     kind: 'pen',
-    texture: '/assets/images/items/pen.png',
+    texture: './assets/images/items/pen.png',
     radius: 1,
     scale: 1,
     width: 42,
@@ -107,7 +107,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   sharpener: {
     kind: 'sharpener',
-    texture: '/assets/images/items/sharpener.png',
+    texture: './assets/images/items/sharpener.png',
     radius: 1,
     scale: 1,
     width: 44,
@@ -116,7 +116,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   sharpener2: {
     kind: 'sharpener2',
-    texture: '/assets/images/items/sharpener2.png',
+    texture: './assets/images/items/sharpener2.png',
     radius: 1,
     scale: 1,
     width: 47,
@@ -125,7 +125,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   ruler: {
     kind: 'ruler',
-    texture: '/assets/images/items/ruler.png',
+    texture: './assets/images/items/ruler.png',
     radius: 1,
     scale: 1,
     width: 31.5,
@@ -134,7 +134,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'triangle-ruler': {
     kind: 'triangle-ruler',
-    texture: '/assets/images/items/triangle-ruler.png',
+    texture: './assets/images/items/triangle-ruler.png',
     radius: 1,
     scale: 1,
     width: 93,
@@ -143,7 +143,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'books-stack': {
     kind: 'books-stack',
-    texture: '/assets/images/items/books-stack.png',
+    texture: './assets/images/items/books-stack.png',
     radius: 1,
     scale: 1,
     width: 104,
@@ -152,7 +152,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'pencil-red': {
     kind: 'pencil-red',
-    texture: '/assets/images/items/pencil-red.png',
+    texture: './assets/images/items/pencil-red.png',
     radius: 1,
     scale: 1,
     width: 54,
@@ -161,7 +161,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'pencil-blue': {
     kind: 'pencil-blue',
-    texture: '/assets/images/items/pencil-blue.png',
+    texture: './assets/images/items/pencil-blue.png',
     radius: 1,
     scale: 1,
     width: 54,
@@ -170,7 +170,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'pencil-yellow': {
     kind: 'pencil-yellow',
-    texture: '/assets/images/items/pencil-yellow.png',
+    texture: './assets/images/items/pencil-yellow.png',
     radius: 1,
     scale: 1,
     width: 54,
@@ -180,7 +180,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
 
   ball: {
     kind: 'ball',
-    texture: '/assets/images/items/ball.png',
+    texture: './assets/images/items/ball.png',
     radius: 1,
     scale: 1,
     width: 82,
@@ -189,7 +189,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   roller: {
     kind: 'roller',
-    texture: '/assets/images/items/skates.png',
+    texture: './assets/images/items/skates.png',
     radius: 1,
     scale: 1,
     width: 92.5,
@@ -198,7 +198,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa1: {
     kind: 'zewa1',
-    texture: '/assets/images/items/zewa1.png',
+    texture: './assets/images/items/zewa1.png',
     radius: 1,
     scale: 1,
     width: 25,
@@ -208,7 +208,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa2: {
     kind: 'zewa2',
-    texture: '/assets/images/items/zewa2.png',
+    texture: './assets/images/items/zewa2.png',
     radius: 1,
     scale: 1,
     width: 25,
@@ -218,7 +218,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa3: {
     kind: 'zewa3',
-    texture: '/assets/images/items/zewa3.png',
+    texture: './assets/images/items/zewa3.png',
     radius: 1,
     scale: 1,
     width: 25,
@@ -228,7 +228,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa4: {
     kind: 'zewa4',
-    texture: '/assets/images/items/zewa4.png',
+    texture: './assets/images/items/zewa4.png',
     radius: 1,
     scale: 1,
     width: 25,
@@ -238,7 +238,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa5: {
     kind: 'zewa5',
-    texture: '/assets/images/items/zewa5.png',
+    texture: './assets/images/items/zewa5.png',
     radius: 1,
     scale: 1,
     width: 25,
@@ -248,7 +248,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa6: {
     kind: 'zewa6',
-    texture: '/assets/images/items/zewa6.png',
+    texture: './assets/images/items/zewa6.png',
     radius: 1,
     scale: 1,
     width: 55,
@@ -258,7 +258,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   zewa7: {
     kind: 'zewa7',
-    texture: '/assets/images/items/zewa7.png',
+    texture: './assets/images/items/zewa7.png',
     radius: 1,
     scale: 1,
     width: 55,
@@ -269,7 +269,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
 
   hammer: {
     kind: 'hammer',
-    texture: '/assets/images/items/hammer.png',
+    texture: './assets/images/items/hammer.png',
     radius: 1,
     scale: 1,
     width: 86,
@@ -278,7 +278,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   boomerang: {
     kind: 'boomerang',
-    texture: '/assets/images/items/boomerang.png',
+    texture: './assets/images/items/boomerang.png',
     radius: 1,
     scale: 1,
     width: 60,
@@ -287,7 +287,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   slingshot: {
     kind: 'slingshot',
-    texture: '/assets/images/items/slingshot.png',
+    texture: './assets/images/items/slingshot.png',
     radius: 1,
     scale: 1,
     width: 45,
@@ -296,7 +296,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   'tennis-racket': {
     kind: 'tennis-racket',
-    texture: '/assets/images/items/tennis-racket.png',
+    texture: './assets/images/items/tennis-racket.png',
     radius: 1,
     scale: 1,
     width: 110,
@@ -305,7 +305,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   gamepad: {
     kind: 'gamepad',
-    texture: '/assets/images/items/gamepad.png',
+    texture: './assets/images/items/gamepad.png',
     radius: 1,
     scale: 1,
     width: 70,
@@ -314,7 +314,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   skateboard: {
     kind: 'skateboard',
-    texture: '/assets/images/items/skateboard.png',
+    texture: './assets/images/items/skateboard.png',
     radius: 1,
     scale: 1,
     width: 130,
@@ -323,7 +323,7 @@ export const ITEM_CATALOG: Record<ItemKind, ItemMeta> = {
   },
   headphones: {
     kind: 'headphones',
-    texture: '/assets/images/items/headphones.png',
+    texture: './assets/images/items/headphones.png',
     radius: 1,
     scale: 1,
     width: 65,

--- a/src/features/game/ui/AnimatedFlyingCoin.tsx
+++ b/src/features/game/ui/AnimatedFlyingCoin.tsx
@@ -43,7 +43,7 @@ export const AnimatedFlyingCoin = ({
 
   return (
     <Container x={x} y={y} scale={scale} alpha={alpha} rotation={rotation} anchor={0.5}>
-      <Sprite image="/assets/images/items/coin.png" width={40} height={40} anchor={0.5} />
+      <Sprite image="./assets/images/items/coin.png" width={40} height={40} anchor={0.5} />
     </Container>
   );
 };

--- a/src/features/game/ui/Background.tsx
+++ b/src/features/game/ui/Background.tsx
@@ -5,7 +5,7 @@ export const Background = ({ width, height }: { width: number; height: number })
   return (
     <>
       <GlowingCoin x={50} y={50} />
-      <Sprite image={'/assets/images/game-bg.jpg'} x={0} y={0} width={width} height={height} />
+      <Sprite image={'./assets/images/game-bg.jpg'} x={0} y={0} width={width} height={height} />
     </>
   );
 };

--- a/src/features/game/ui/BackpackBack.tsx
+++ b/src/features/game/ui/BackpackBack.tsx
@@ -13,7 +13,7 @@ export const BackpackBack = ({
 }) => {
   return (
     <Container x={x} y={y + 10}>
-      <Sprite image="/assets/images/backpack-back.png" width={width} height={height} anchor={0.5} />
+      <Sprite image="./assets/images/backpack-back.png" width={width} height={height} anchor={0.5} />
     </Container>
   );
 };

--- a/src/features/game/ui/BackpackFront.tsx
+++ b/src/features/game/ui/BackpackFront.tsx
@@ -14,7 +14,7 @@ export const BackpackFront = ({
   return (
     <Container x={x} y={y}>
       <Sprite
-        image="/assets/images/backpack-front.png"
+        image="./assets/images/backpack-front.png"
         width={width}
         height={height}
         anchor={0.5}

--- a/src/features/game/ui/GameUIOverlay.tsx
+++ b/src/features/game/ui/GameUIOverlay.tsx
@@ -40,14 +40,14 @@ export const GameUIOverlay = () => {
                   <img
                     width="30"
                     height="30"
-                    src="/assets/images/items/coin.png"
+                    src="./assets/images/items/coin.png"
                     alt="иконка монета"
                   />
                 </div>
                 {coins}
               </Flex>
               <Flex gap="4px">
-                <img src="/assets/images/backpack-icon.png" alt="иконка рюкзак" />
+                <img src="./assets/images/backpack-icon.png" alt="иконка рюкзак" />
                 {score}
               </Flex>
             </Flex>

--- a/src/features/game/ui/GlowingCoin.tsx
+++ b/src/features/game/ui/GlowingCoin.tsx
@@ -19,7 +19,7 @@ export const GlowingCoin = ({ x, y, size = 64 }: { x: number; y: number; size?: 
       {/* Лучи */}
       <Sprite
         ref={raysRef}
-        image="/assets/images/coin-rays.png"
+        image="./assets/images/coin-rays.png"
         width={size * 2}
         height={size * 2}
         anchor={0.5}
@@ -29,7 +29,7 @@ export const GlowingCoin = ({ x, y, size = 64 }: { x: number; y: number; size?: 
       {/* Свечение */}
       <Sprite
         ref={glowRef}
-        image="/assets/images/coin-glow.png"
+        image="./assets/images/coin-glow.png"
         width={size * 1.5}
         height={size * 1.5}
         anchor={0.5}
@@ -37,7 +37,7 @@ export const GlowingCoin = ({ x, y, size = 64 }: { x: number; y: number; size?: 
         blendMode={PIXI.BLEND_MODES.ADD}
       />
       {/* Монетка */}
-      <Sprite image="/assets/images/items/coin.png" width={size} height={size} anchor={0.5} />
+      <Sprite image="./assets/images/items/coin.png" width={size} height={size} anchor={0.5} />
     </Container>
   );
 };

--- a/src/features/game/ui/onboardingScreens/Screen1.tsx
+++ b/src/features/game/ui/onboardingScreens/Screen1.tsx
@@ -6,19 +6,19 @@ import { ForwardIcon, LeftIcon } from '@/shared/ui';
 export const Screen1 = () => {
   return (
     <>
-      <Domovenok src={'/assets/images/onboarding/domovenok1.png'} alt={`domovenok`} />
+      <Domovenok src={'./assets/images/onboarding/domovenok1.png'} alt={`domovenok`} />
       <BackPack
         width={BACKPACK_WIDTH}
-        src={'/assets/images/onboarding/backpack.png'}
+        src={'./assets/images/onboarding/backpack.png'}
         alt={`backpack`}
       />
       <BackpackCounter>
         <InfoBlock>
-          <img src="/assets/images/backpack-icon.png" alt="иконка рюкзак" />0
+          <img src="./assets/images/backpack-icon.png" alt="иконка рюкзак" />0
         </InfoBlock>
       </BackpackCounter>
       <Bubble1>
-        <Bubble1Img src={'/assets/images/onboarding/bubble1.png'} alt={`Bubble`} />
+        <Bubble1Img src={'./assets/images/onboarding/bubble1.png'} alt={`Bubble`} />
       </Bubble1>
       <ControlsWrapper>
         <ArrowButton>

--- a/src/features/game/ui/onboardingScreens/Screen2.tsx
+++ b/src/features/game/ui/onboardingScreens/Screen2.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 export const Screen2 = () => {
   return (
     <>
-      <Items src="/assets/images/onboarding/items.png" />
-      <Domovenok src="/assets/images/onboarding/domovenok2.png" />
+      <Items src="./assets/images/onboarding/items.png" />
+      <Domovenok src="./assets/images/onboarding/domovenok2.png" />
       <Bubble>
-        <img src={'/assets/images/onboarding/bubble2.png'} alt={`Bubble`} />
+        <img src={'./assets/images/onboarding/bubble2.png'} alt={`Bubble`} />
       </Bubble>
     </>
   );

--- a/src/features/game/ui/onboardingScreens/Screen3.tsx
+++ b/src/features/game/ui/onboardingScreens/Screen3.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 export const Screen3 = () => {
   return (
     <>
-      <Items style={{ filter: 'brightness(0.35)' }} src="/assets/images/onboarding/items3.png" />
-      <Items src="/assets/images/onboarding/items2.png" />
-      <Domovenok src="/assets/images/onboarding/domovenok3.png" />
+      <Items style={{ filter: 'brightness(0.35)' }} src="./assets/images/onboarding/items3.png" />
+      <Items src="./assets/images/onboarding/items2.png" />
+      <Domovenok src="./assets/images/onboarding/domovenok3.png" />
       <Bubble>
-        <img src={'/assets/images/onboarding/bubble3.png'} alt={`Bubble`} />
+        <img src={'./assets/images/onboarding/bubble3.png'} alt={`Bubble`} />
       </Bubble>
     </>
   );

--- a/src/features/game/ui/onboardingScreens/Screen4.tsx
+++ b/src/features/game/ui/onboardingScreens/Screen4.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 export const Screen4 = () => {
   return (
     <>
-      <Domovenok src="/assets/images/onboarding/domovenok4.png" />
+      <Domovenok src="./assets/images/onboarding/domovenok4.png" />
       <Bubble>
-        <img src={'/assets/images/onboarding/bubble4.png'} alt={`Bubble`} />
+        <img src={'./assets/images/onboarding/bubble4.png'} alt={`Bubble`} />
       </Bubble>
     </>
   );

--- a/src/features/home/HomeScreen.styles.ts
+++ b/src/features/home/HomeScreen.styles.ts
@@ -5,7 +5,7 @@ export const HomeWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 24px 16px;
-  background: url('/assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
+  background: url('./assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
   min-height: 100vh;
 `;
 

--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -18,7 +18,7 @@ export function HomeScreen() {
         <Flex justify="space-between">
           <ZewaButton variant="white">
             <Flex gap="6px">
-              <img src="/assets/images/coin-icon.png" alt="монетка" />
+              <img src="./assets/images/coin-icon.png" alt="монетка" />
               745
             </Flex>
           </ZewaButton>
@@ -33,7 +33,7 @@ export function HomeScreen() {
         </Flex>
       </Navigation>
       <BackpackContainer>
-        <Backpack src="/assets/images/backpack.png" alt="Backpack" />
+        <Backpack src="./assets/images/backpack.png" alt="Backpack" />
         <ZewaButton variant="play" icon={<PlayIcon />} onClick={() => navigate('/game')}>
           ИГРАТЬ
         </ZewaButton>

--- a/src/features/splash/SplashScreen.tsx
+++ b/src/features/splash/SplashScreen.tsx
@@ -1,5 +1,5 @@
-import zewaLogo from '/assets/images/zewa-logo.png';
-import rollBg from '/assets/images/roll-bg.png';
+import zewaLogo from './assets/images/zewa-logo.png';
+import rollBg from './assets/images/roll-bg.png';
 import * as S from './style';
 
 export function SplashScreen() {

--- a/src/features/splash/style.ts
+++ b/src/features/splash/style.ts
@@ -7,7 +7,7 @@ export const fill = keyframes`
 
 export const Wrapper = styled.div`
   height: 100vh;
-  background: url('/assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
+  background: url('./assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
 
   display: flex;
   flex-direction: column;

--- a/src/shared/ui/modal/style.ts
+++ b/src/shared/ui/modal/style.ts
@@ -70,7 +70,7 @@ export const CloseBtn = styled.button`
   &::before {
     content: '';
     position: absolute;
-    background: url('/assets/images/corner.svg') no-repeat right top;
+    background: url('./assets/images/corner.svg') no-repeat right top;
     width: 2.5rem;
     height: 2.5rem;
     background-size: contain;

--- a/src/shared/ui/page-container/PageContainer.style.ts
+++ b/src/shared/ui/page-container/PageContainer.style.ts
@@ -6,7 +6,7 @@ export const Wrapper = styled.div<{
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: url('/assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
+  background: url('./assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
 
   ${({ $fullscreen }) =>
     $fullscreen &&


### PR DESCRIPTION
## Summary
- use relative image paths so github pages resolves assets correctly

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_6851c4422bb88323aeb2e9ada1cdbf88