### PR TITLE
Fix game restart logic and add unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@pixi/filter-glow": "^5.2.1",
     "@pixi/react": "^7.1.2",
+    "@testing-library/dom": "^10.4.0",
     "antd": "^5.26.0",
     "axios": "^1.9.0",
     "classnames": "^2.5.1",

--- a/src/features/game/__tests__/GameRestart.test.tsx
+++ b/src/features/game/__tests__/GameRestart.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useGameTicker } from '../lib/hooks/useGameTicker';
+import { useGameModelStore } from '../model/gameModelStore';
+
+let tickCallback: (delta: number) => void = () => {};
+vi.mock('@pixi/react', () => ({
+  useTick: (fn: (d: number) => void) => {
+    tickCallback = fn;
+  },
+}));
+
+const isIntersectingMock = vi.fn();
+vi.mock('../lib/collision', () => ({
+  isIntersecting: (...args: any[]) => isIntersectingMock(...args),
+}));
+
+const ADD_STEPS = 97; // ~1600ms
+
+const createItem = (y: number) => ({
+  id: `item${spawnCount}`,
+  kind: 'marker' as const,
+  x: 50,
+  y,
+  radius: 10,
+  speed: 0,
+  attachedOffsetX: null,
+});
+
+let spawnCount = 0;
+const addItem = vi.fn(() => {
+  const y = spawnCount === 0 ? 50 : 201;
+  const item = createItem(y);
+  useGameModelStore.setState((s) => ({ items: [...s.items, item] }));
+  spawnCount += 1;
+});
+
+const spawnCoin = vi.fn();
+
+describe('game restart flow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spawnCount = 0;
+    useGameModelStore.getState().resetGame();
+    useGameModelStore.setState({
+      addItem,
+      spawnCoin,
+      canvasWidth: 100,
+      isPaused: false,
+      isGameStarted: true,
+    });
+    isIntersectingMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('spawns items and applies logic after reset', () => {
+    renderHook(() => useGameTicker(100, 200));
+    for (let i = 0; i < ADD_STEPS; i++) {
+      tickCallback(1);
+    }
+    expect(useGameModelStore.getState().score).toBe(1);
+
+    useGameModelStore.getState().stopGame();
+    useGameModelStore.getState().resetGame();
+    useGameModelStore.setState({ addItem, spawnCoin, isPaused: false });
+    isIntersectingMock.mockReturnValue(false);
+    useGameModelStore.getState().startGame();
+
+    for (let i = 0; i < ADD_STEPS; i++) {
+      tickCallback(1);
+    }
+    expect(useGameModelStore.getState().lives).toBe(2);
+  });
+});

--- a/src/features/game/lib/hooks/useGameTicker.ts
+++ b/src/features/game/lib/hooks/useGameTicker.ts
@@ -1,5 +1,5 @@
 import { useTick } from '@pixi/react';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { useGameModelStore } from '@/features/game/model/gameModelStore';
 
 export const useGameTicker = (canvasWidth: number, canvasHeight: number) => {
@@ -11,6 +11,10 @@ export const useGameTicker = (canvasWidth: number, canvasHeight: number) => {
 
   const timer = useRef(0);
   const ADD_INTERVAL = 1600;
+
+  useEffect(() => {
+    timer.current = 0;
+  }, [isGameStarted]);
 
   useTick((delta: number) => {
     if (!isGameStarted || isPaused) return;

--- a/src/features/game/ui/__tests__/BackpackControls.test.tsx
+++ b/src/features/game/ui/__tests__/BackpackControls.test.tsx
@@ -18,7 +18,7 @@ describe('BackpackControls', () => {
   beforeEach(() => {
     moveLeft.mockClear();
     moveRight.mockClear();
-    useGameModelStore.setState({ moveLeft, moveRight });
+    useGameModelStore.setState({ moveLeft, moveRight, isGameStarted: true });
     (useCoinAnimationStore as unknown as vi.Mock).mockReturnValue({ flyingCoins: [] });
   });
 


### PR DESCRIPTION
## Summary
- reset ticker timer when game restarts
- ensure backpack controls test sets game start flag
- add integration test for restarting the game
- depend on `@testing-library/dom` for tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851c0e4d09c8323a3cd2e154460f7da