### PR TITLE
Implement QR scanner modal

### DIFF
--- a/src/features/checks/lib/index.ts
+++ b/src/features/checks/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './renderQrScannerModal';

--- a/src/features/checks/lib/renderQrScannerModal.tsx
+++ b/src/features/checks/lib/renderQrScannerModal.tsx
@@ -1,0 +1,23 @@
+import { useModalStore } from '@/shared/model/modalStore';
+import { ZewaButton } from '@/shared/ui';
+import { Flex } from 'antd';
+
+export const renderQrScannerModal = () => {
+  useModalStore.getState().openModal({
+    title: 'Сканер QR-кодов',
+    closable: true,
+    content: (
+      <Flex vertical gap="10px">
+        <ZewaButton variant="blue-b" onClick={() => {}}>
+          СКАНИРОВАТЬ
+        </ZewaButton>
+        <ZewaButton variant="blue-b" onClick={() => {}}>
+          ЗАГРУЗИТЬ СКРИНШОТ
+        </ZewaButton>
+        <ZewaButton variant="blue-b" onClick={() => {}}>
+          ВВЕСТИ ДАННЫЕ ВРУЧНУЮ
+        </ZewaButton>
+      </Flex>
+    ),
+  });
+};

--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -6,6 +6,7 @@ import {
   Navigation,
 } from './HomeScreen.styles';
 import { PlayIcon, ScanIcon, TournamentIcon, UserIcon, ZewaButton } from '@/shared/ui';
+import { renderQrScannerModal } from '@/features';
 import { useNavigate } from 'react-router-dom';
 import { Flex } from 'antd';
 
@@ -39,8 +40,13 @@ export function HomeScreen() {
         </ZewaButton>
       </BackpackContainer>
       <ButtonsWrapper>
-        <ZewaButton style={{ padding: '14px' }} variant="white" icon={<ScanIcon />}>
-          Загрузить чек
+        <ZewaButton
+          style={{ padding: '14px' }}
+          variant="white"
+          icon={<ScanIcon />}
+          onClick={renderQrScannerModal}
+        >
+          Сканировать чек
         </ZewaButton>
         <ZewaButton style={{ padding: '14px' }} variant="white" onClick={() => navigate('/rules')}>
           Правила участия

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -9,3 +9,4 @@ export * from './tournament/TournamentScreen';
 export * from './game';
 export * from './error/ErrorPage';
 export * from './profile/ProfileScreen';
+export * from './checks/lib/renderQrScannerModal';


### PR DESCRIPTION
## Summary
- add a modal helper for QR scanning
- wire modal up to the Home page

## Testing
- `npm run lint` *(fails: Unexpected any in existing tests)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a4a0a73c8323b0ccb41c49387f90