### PR TITLE
Expand Telegram Mini App on mobile

### DIFF
--- a/src/services/TelegramService.ts
+++ b/src/services/TelegramService.ts
@@ -15,6 +15,8 @@ export interface TelegramWebApp {
   };
   close: () => void;
   expand: () => void;
+  /** Disable vertical swipe gestures that close or minimize the Mini App */
+  disableVerticalSwipes?: () => void;
   ready: () => void;
   sendData: (data: string) => void;
   onEvent: (...args: any[]) => void;
@@ -26,6 +28,13 @@ export class TelegramService {
   init() {
     this.tg = window?.Telegram?.WebApp;
     this.tg?.ready();
+
+    // Expand the Web App to full screen on mobile devices
+    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    if (isMobile) {
+      this.tg?.expand?.();
+      this.tg?.disableVerticalSwipes?.();
+    }
   }
 
   onEvent(eventType: string, callback: (...args: unknown[]) => void) {


### PR DESCRIPTION
## Summary
- auto expand Telegram mini app to full screen on mobile
- disable vertical swipe gesture that hides the app

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad20cd1c8323ae553c43877f1c9c