### PR TITLE
Implement Telegram QR scan

### DIFF
--- a/src/features/checks/ScannerComponent.tsx
+++ b/src/features/checks/ScannerComponent.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { Flex } from 'antd';
+import { telegramService } from '@/services/TelegramService';
+import { useModalStore } from '@/shared/model/modalStore';
+import { KeyboardIcon, ScanWhiteIcon, ScreenshotIcon, ZewaButton, Text } from '@/shared/ui';
+import { parseReceipt } from './lib/parseReceipt';
+
+const renderManualInputModal = () => {
+  useModalStore.getState().openModal({
+    title: 'Ручной ввод',
+    closable: true,
+    content: <div>TODO: manual input</div>,
+  });
+};
+
+const renderUploadFormModal = () => {
+  useModalStore.getState().openModal({
+    title: 'Загрузить фото',
+    closable: true,
+    content: <div>TODO: upload form</div>,
+  });
+};
+
+const renderScanErrorModal = (message: string) => {
+  useModalStore.getState().openModal({
+    title: 'Чек не распознан',
+    closable: true,
+    content: (
+      <Flex vertical gap="10px">
+        <Text size="p4" align="center">{message}</Text>
+        <ZewaButton variant="blue-b" onClick={renderManualInputModal}>
+          <Flex align="center" gap="5px">
+            <KeyboardIcon /> Ввести вручную
+          </Flex>
+        </ZewaButton>
+        <ZewaButton variant="blue-b" onClick={renderUploadFormModal}>
+          <Flex align="center" gap="5px">
+            <ScreenshotIcon /> Загрузить фото
+          </Flex>
+        </ZewaButton>
+      </Flex>
+    ),
+  });
+};
+
+export function ScannerComponent() {
+  useEffect(() => {
+    const handleQr = (code: string) => {
+      try {
+        parseReceipt(code);
+        useModalStore.getState().closeModal();
+      } catch (e) {
+        renderScanErrorModal((e as Error).message);
+      }
+    };
+
+    const handleError = () => {
+      renderScanErrorModal('Произошла ошибка при сканировании');
+    };
+
+    telegramService.onEvent('qrCodeReceived', handleQr);
+    telegramService.onEvent('onScanError', handleError);
+    telegramService.onEvent('scanQrPopupClosed', handleError);
+  }, []);
+
+  return (
+    <Flex vertical gap="10px">
+      <ZewaButton variant="blue-b" onClick={() => telegramService.showScanQrPopup()}>
+        <Flex align="center" gap="5px">
+          <ScanWhiteIcon /> Сканировать чек
+        </Flex>
+      </ZewaButton>
+      <ZewaButton variant="blue-b" onClick={renderUploadFormModal}>
+        <Flex align="center" gap="5px">
+          <ScreenshotIcon /> Загрузить скриншот
+        </Flex>
+      </ZewaButton>
+      <ZewaButton variant="blue-b" onClick={renderManualInputModal}>
+        <Flex align="center" gap="5px">
+          <KeyboardIcon /> Ввести вручную
+        </Flex>
+      </ZewaButton>
+    </Flex>
+  );
+}

--- a/src/features/checks/__tests__/parseReceipt.test.ts
+++ b/src/features/checks/__tests__/parseReceipt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { parseReceipt } from '../lib/parseReceipt';
+
+describe('parseReceipt', () => {
+  it('parses valid receipt', () => {
+    const raw = '{"date":"2025-06-18","totalSum":123,"shopId":"123456"}';
+    expect(parseReceipt(raw)).toEqual({ date: '2025-06-18', totalSum: 123, shopId: '123456' });
+  });
+
+  it('throws on invalid json', () => {
+    expect(() => parseReceipt('not-json')).toThrow();
+  });
+
+  it('throws on missing fields', () => {
+    expect(() => parseReceipt('{"date":"2025-06-18"}')).toThrow();
+  });
+
+  it('throws on invalid shopId', () => {
+    const raw = '{"date":"2025-06-18","totalSum":123,"shopId":"abc"}';
+    expect(() => parseReceipt(raw)).toThrow();
+  });
+});

--- a/src/features/checks/lib/parseReceipt.ts
+++ b/src/features/checks/lib/parseReceipt.ts
@@ -1,0 +1,34 @@
+export interface Receipt {
+  date: string;
+  totalSum: number;
+  shopId: string;
+  [key: string]: unknown;
+}
+
+export const SHOP_ID_PATTERN = /^\d{6}$/;
+
+export function parseReceipt(raw: string): Receipt {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('Некорректный формат данных');
+  }
+
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    !('date' in data) ||
+    !('totalSum' in data) ||
+    !('shopId' in data)
+  ) {
+    throw new Error('Отсутствуют обязательные поля');
+  }
+
+  const receipt = data as Receipt;
+  if (!SHOP_ID_PATTERN.test(receipt.shopId)) {
+    throw new Error('shopId не соответствует формату');
+  }
+
+  return receipt;
+}

--- a/src/features/checks/lib/renderQrScannerModal.tsx
+++ b/src/features/checks/lib/renderQrScannerModal.tsx
@@ -1,29 +1,10 @@
 import { useModalStore } from '@/shared/model/modalStore';
-import { KeyboardIcon, ScanWhiteIcon, ScreenshotIcon, ZewaButton } from '@/shared/ui';
-import { Flex } from 'antd';
+import { ScannerComponent } from '../ScannerComponent';
 
 export const renderQrScannerModal = () => {
   useModalStore.getState().openModal({
     title: 'Сканер QR-кодов',
     closable: true,
-    content: (
-      <Flex vertical gap="10px">
-        <ZewaButton variant="blue-b" onClick={() => {}}>
-          <Flex align="center" gap="5px">
-            <ScanWhiteIcon /> Сканировать
-          </Flex>
-        </ZewaButton>
-        <ZewaButton variant="blue-b" onClick={() => {}}>
-          <Flex align="center" gap="5px">
-            <ScreenshotIcon /> Загрузить скриншот
-          </Flex>
-        </ZewaButton>
-        <ZewaButton variant="blue-b" onClick={() => {}}>
-          <Flex align="center" gap="5px">
-            <KeyboardIcon /> Ввести вручную
-          </Flex>
-        </ZewaButton>
-      </Flex>
-    ),
+    content: <ScannerComponent />,
   });
 };

--- a/src/services/TelegramService.ts
+++ b/src/services/TelegramService.ts
@@ -18,6 +18,7 @@ export interface TelegramWebApp {
   ready: () => void;
   sendData: (data: string) => void;
   onEvent: (...args: any[]) => void;
+  showScanQrPopup: () => void;
 }
 
 export class TelegramService {
@@ -46,6 +47,10 @@ export class TelegramService {
 
   close() {
     this.tg?.close();
+  }
+
+  showScanQrPopup() {
+    (this.tg as any)?.showScanQrPopup();
   }
 }
 


### PR DESCRIPTION
## Summary
- add Telegram QR scanner component
- validate QR receipt parsing
- show scanner modal using the new component
- expose `showScanQrPopup` helper in Telegram service
- test receipt parser

## Testing
- `npx vitest run` *(fails: GameRestart.test)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac5fd1ac83238b289084df061a9e