### PR TITLE
Implement tournament screen with tabs

### DIFF
--- a/src/features/tournament/TournamentScreen.styles.ts
+++ b/src/features/tournament/TournamentScreen.styles.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export const TabsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 16px;
+`;
+
+export const TabButton = styled.button<{ $active?: boolean }>`
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-family: 'Foco Trial';
+  font-size: 16px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  color: ${({ $active }) => ($active ? '#fff' : '#1235ab')};
+  background: ${({ $active }) =>
+    $active
+      ? 'linear-gradient(180deg, #2d59df 0%, #1945cb 100%)'
+      : 'linear-gradient(180deg, #f4fcff 0%, #e3f7ff 100%)'};
+`;
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  color: #fff;
+
+  th,
+  td {
+    padding: 8px;
+    text-align: left;
+  }
+
+  th {
+    font-weight: 700;
+    border-bottom: 2px solid rgba(255, 255, 255, 0.3);
+  }
+
+  td {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  }
+`;
+
+export const PrizeItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: linear-gradient(180deg, #f4fcff 0%, #e3f7ff 100%);
+  border-radius: 10px;
+  padding: 8px;
+  color: #1235ab;
+  font-family: 'Foco Trial';
+  font-size: 16px;
+  margin-bottom: 8px;
+`;

--- a/src/features/tournament/TournamentScreen.tsx
+++ b/src/features/tournament/TournamentScreen.tsx
@@ -1,9 +1,86 @@
-import { PageContainer } from '@/shared/ui';
+import { useState } from 'react';
+import { PageContainer, Text } from '@/shared/ui';
+import { maskName } from '@/utils';
+import * as S from './TournamentScreen.styles';
+
+interface Player {
+  place: number;
+  name: string;
+  points: number;
+}
+
+interface Winner {
+  name: string;
+  prize: string;
+  image: string;
+}
+
+const topPlayers: Player[] = [
+  { place: 1, name: 'Алексей', points: 1500 },
+  { place: 2, name: 'Мария', points: 1300 },
+  { place: 3, name: 'Иван', points: 1200 },
+  { place: 4, name: 'Екатерина', points: 1100 },
+  { place: 5, name: 'Дмитрий', points: 1000 },
+];
+
+const winners: Winner[] = [
+  {
+    name: 'Ольга Петрова',
+    prize: 'Скейтборд',
+    image: './assets/images/items/skateboard.png',
+  },
+  {
+    name: 'Никита Сидоров',
+    prize: 'Наушники',
+    image: './assets/images/items/headphones.png',
+  },
+];
 
 export function TournamentScreen() {
+  const [active, setActive] = useState<'players' | 'winners'>('players');
+
   return (
     <PageContainer fullscreen scrollable title="Турнирная таблица">
-      <div>Экран: Турнирная таблица</div>
+      <S.TabsWrapper>
+        <S.TabButton $active={active === 'players'} onClick={() => setActive('players')}>
+          Лучшие игроки
+        </S.TabButton>
+        <S.TabButton $active={active === 'winners'} onClick={() => setActive('winners')}>
+          Выигрыши
+        </S.TabButton>
+      </S.TabsWrapper>
+      {active === 'players' ? (
+        <S.Table>
+          <thead>
+            <tr>
+              <th>Место</th>
+              <th>Имя</th>
+              <th>Очки</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topPlayers.map((p) => (
+              <tr key={p.place}>
+                <td>{p.place}</td>
+                <td>{maskName(p.name)}</td>
+                <td>{p.points}</td>
+              </tr>
+            ))}
+          </tbody>
+        </S.Table>
+      ) : (
+        <div>
+          {winners.map((w, i) => (
+            <S.PrizeItem key={i}>
+              <img src={w.image} alt={w.prize} width={50} height={50} />
+              <div>
+                <Text weight={700}>{maskName(w.name)}</Text>
+                <Text size="p4">{w.prize}</Text>
+              </div>
+            </S.PrizeItem>
+          ))}
+        </div>
+      )}
     </PageContainer>
   );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './nbsp';
+export * from './maskName';

--- a/src/utils/maskName.ts
+++ b/src/utils/maskName.ts
@@ -1,0 +1,5 @@
+export function maskName(name: string, visibleChars = 2): string {
+  if (!name) return '';
+  if (name.length <= visibleChars) return '*'.repeat(name.length);
+  return name.slice(0, visibleChars) + '*'.repeat(name.length - visibleChars);
+}


### PR DESCRIPTION
## Summary
- show leaderboard and prize winners
- provide helper to mask player names

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad856814832396f4585fc6da78b0