### PR TITLE
Add API service and hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useContainerSize';
 export * from './useSwipe';
+export * from './useApi';

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+
+export interface ApiHookResult<TRequest, TResponse> {
+  data: TResponse | null;
+  loading: boolean;
+  error: unknown;
+  call: (payload: TRequest) => Promise<TResponse>;
+}
+
+export function useApi<TRequest, TResponse>(
+  requestFn: (payload: TRequest) => Promise<TResponse> | Promise<{ data: TResponse }>,
+): ApiHookResult<TRequest, TResponse> {
+  const [data, setData] = useState<TResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const call = useCallback(
+    async (payload: TRequest): Promise<TResponse> => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await requestFn(payload);
+        const result = (res as any).data ?? res;
+        setData(result);
+        return result as TResponse;
+      } catch (err) {
+        setError(err);
+        throw err as Error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [requestFn],
+  );
+
+  return { data, loading, error, call };
+}

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -1,0 +1,96 @@
+import axios, { type AxiosInstance } from 'axios';
+
+export interface StartRequest {
+  telegram_id: number;
+  username: string;
+  ts: number;
+  payload: string;
+}
+
+export interface HistoryRequest {
+  telegram_id: number;
+}
+
+export type CouponType = 'barcode' | 'code';
+export interface ActivateCouponRequest {
+  telegram_id: number;
+  type: CouponType;
+  coupon_id: string | number;
+}
+
+export interface AddCheckRequest {
+  telegram_id: number;
+  img?: File;
+  fn?: string;
+  fd?: string;
+  fp?: string;
+  sum?: string;
+  date?: string;
+}
+
+export interface GameStartRequest {
+  telegram_id: number;
+  ts: number;
+  payload: string;
+  game: number;
+}
+
+export interface GameResultRequest {
+  telegram_id: number;
+  ts: number;
+  payload: string;
+  game: number;
+  result: number;
+  points: number;
+  coins: number;
+}
+
+export class ApiService {
+  private axios: AxiosInstance;
+  private hash = '';
+
+  constructor(baseURL = import.meta.env.VITE_API_BASE_URL || '/api') {
+    this.axios = axios.create({ baseURL });
+  }
+
+  setHash(hash: string) {
+    this.hash = hash;
+  }
+
+  private withHash<T extends Record<string, unknown>>(data: T): T & { hash: string } {
+    return { ...data, hash: this.hash };
+  }
+
+  start(data: Omit<StartRequest, 'hash'>) {
+    return this.axios.post('/start', this.withHash(data));
+  }
+
+  history(data: Omit<HistoryRequest, 'hash'>) {
+    return this.axios.post('/history', this.withHash(data));
+  }
+
+  activateCoupon(data: Omit<ActivateCouponRequest, 'hash'>) {
+    return this.axios.post('/activate-coupon', this.withHash(data));
+  }
+
+  addCheck(data: Omit<AddCheckRequest, 'hash'>) {
+    const form = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        form.append(key, value as any);
+      }
+    });
+    form.append('hash', this.hash);
+    return this.axios.post('/add-check', form);
+  }
+
+  gameStart(data: Omit<GameStartRequest, 'hash'>) {
+    return this.axios.post('/game/start', this.withHash(data));
+  }
+
+  gameResult(data: Omit<GameResultRequest, 'hash'>) {
+    return this.axios.post('/game/result', this.withHash(data));
+  }
+}
+
+export const apiService = new ApiService();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './TelegramService';
+export * from './ApiService';


### PR DESCRIPTION
## Summary
- create an ApiService wrapper using axios
- add useApi hook for async API calls
- export new utilities

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4c6970b88323a8161c4ef9d3ceef