### PR TITLE
Implement start API call on Telegram auth

### DIFF
--- a/src/contexts/TelegramContext.tsx
+++ b/src/contexts/TelegramContext.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useEffect, type ReactNode } from 'react';
 import { telegramService } from '../services/TelegramService';
+import { apiService } from '../services/ApiService';
 import { useUserStore } from '../shared/model';
 
 export const TelegramContext = createContext(telegramService);
 
 export function TelegramProvider({ children }: { children: ReactNode }) {
   const setUser = useUserStore((s) => s.setUser);
+  const setStartData = useUserStore((s) => s.setStartData);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -18,7 +20,8 @@ export function TelegramProvider({ children }: { children: ReactNode }) {
         telegramService.disableVerticalSwipes();
 
         const user = telegramService.getUser();
-        if (user) {
+        const webApp = telegramService.getWebApp();
+        if (user && webApp) {
           setUser({
             id: user.id,
             firstName: user.first_name,
@@ -26,12 +29,23 @@ export function TelegramProvider({ children }: { children: ReactNode }) {
             username: user.username,
             photoUrl: user.photo_url,
           });
+
+          apiService.setHash(webApp.initDataUnsafe?.hash ?? '');
+          apiService
+            .start({
+              telegram_id: user.id,
+              username: user.username ?? '',
+              ts: parseInt(webApp.initDataUnsafe?.auth_date ?? '0', 10),
+              payload: webApp.initData,
+            })
+            .then((res) => setStartData(res.data))
+            .catch((err) => console.error('start error', err));
         }
       }
     }, 100);
 
     return () => clearInterval(interval);
-  }, [setUser]);
+  }, [setUser, setStartData]);
 
   return <TelegramContext.Provider value={telegramService}>{children}</TelegramContext.Provider>;
 }

--- a/src/shared/model/userStore.ts
+++ b/src/shared/model/userStore.ts
@@ -11,7 +11,12 @@ interface User {
 interface UserStore {
   user: User | null;
   coins: number;
+  /**
+   * Data returned from `/api/start` endpoint.
+   */
+  startData: unknown | null;
   setUser: (user: User) => void;
+  setStartData: (data: unknown) => void;
   addCoins: (amount: number) => void;
   reset: () => void;
 }
@@ -19,7 +24,9 @@ interface UserStore {
 export const useUserStore = create<UserStore>((set) => ({
   user: null,
   coins: 0,
+  startData: null,
   setUser: (user) => set({ user }),
+  setStartData: (data) => set({ startData: data }),
   addCoins: (amount) => set((state) => ({ coins: state.coins + amount })),
-  reset: () => set({ user: null, coins: 0 }),
+  reset: () => set({ user: null, coins: 0, startData: null }),
 }));


### PR DESCRIPTION
## Summary
- store `/api/start` response in user store
- trigger `/api/start` after Telegram auth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5095730c8323b443b396733e31e1