### PR TITLE
Add onboarding screen stub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,18 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { SplashScreen } from './features/splash/SplashScreen';
+import { OnboardingScreen } from './features/onboarding';
 import { AppRouter } from './router';
 import { ZewaModal } from './shared/ui';
 import { AdaptivityProvider, AppRoot, ConfigProvider, SafeAreaInsets } from '@vkontakte/vkui';
 import { GlobalProvider } from './contexts/GlobalProvider';
 
 export default function App() {
-  const loading = false;
+  const [stage, setStage] = useState<'splash' | 'onboarding' | 'app'>('splash');
+
+  useEffect(() => {
+    const id = setTimeout(() => setStage('onboarding'), 1500);
+    return () => clearTimeout(id);
+  }, []);
 
   const insets: SafeAreaInsets = {
     top: 20,
@@ -15,7 +21,8 @@ export default function App() {
     right: 0,
   };
 
-  if (loading) return <SplashScreen />;
+  if (stage === 'splash') return <SplashScreen />;
+  if (stage === 'onboarding') return <OnboardingScreen onFinish={() => setStage('app')} />;
 
   return (
     <GlobalProvider>

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -10,3 +10,4 @@ export * from './game';
 export * from './error/ErrorPage';
 export * from './profile/ProfileScreen';
 export * from './checks/lib/renderQrScannerModal';
+export * from './onboarding';

--- a/src/features/onboarding/OnboardingScreen.styles.ts
+++ b/src/features/onboarding/OnboardingScreen.styles.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px;
+  height: 100vh;
+  background: url('./assets/images/bg.svg'), linear-gradient(180deg, #2d59df 0%, #1945cb 100%);
+  color: #fff;
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  border-radius: 20px;
+  margin-bottom: 24px;
+`;
+
+export const Text = styled.p`
+  text-align: center;
+  font-family: 'Foco Trial';
+  font-size: 18px;
+  line-height: 130%;
+  margin-bottom: 24px;
+  color: #fff;
+`;
+
+export const Pagination = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+`;
+
+export const Dot = styled.span<{ $active?: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ $active }) => ($active ? '#fff' : 'rgba(255, 255, 255, 0.5)')};
+`;
+
+export const SkipButton = styled.button`
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-family: 'Foco Trial';
+  font-size: 16px;
+  margin-top: 8px;
+  cursor: pointer;
+`;

--- a/src/features/onboarding/OnboardingScreen.tsx
+++ b/src/features/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { ZewaButton } from '@/shared/ui';
+import * as S from './OnboardingScreen.styles';
+
+interface OnboardingScreenProps {
+  onFinish: () => void;
+}
+
+const steps = [
+  {
+    image: './assets/images/roll-bg.png',
+    text: 'Добро пожаловать в приложение Zewa',
+  },
+  {
+    image: './assets/images/roll-bg.png',
+    text: 'Сканируйте чеки и получайте призы',
+  },
+  {
+    image: './assets/images/roll-bg.png',
+    text: 'Играйте и участвуйте в турнирах',
+  },
+];
+
+export function OnboardingScreen({ onFinish }: OnboardingScreenProps) {
+  const [step, setStep] = useState(0);
+
+  const handleNext = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      onFinish();
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.Image src={steps[step].image} alt="onboarding" />
+      <S.Text>{steps[step].text}</S.Text>
+      <ZewaButton variant="blue-b" onClick={handleNext} style={{ marginTop: 'auto' }}>
+        Далее
+      </ZewaButton>
+      <S.Pagination>
+        {steps.map((_, i) => (
+          <S.Dot key={i} $active={i === step} />
+        ))}
+      </S.Pagination>
+      <S.SkipButton onClick={onFinish}>Пропустить</S.SkipButton>
+    </S.Wrapper>
+  );
+}

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,1 @@
+export * from './OnboardingScreen';


### PR DESCRIPTION
## Summary
- show splash only at launch and display onboarding placeholder
- implement simple onboarding carousel with skip button

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1206259083238a5280467188d500