### PR TITLE
Store start response data

### DIFF
--- a/src/contexts/TelegramContext.tsx
+++ b/src/contexts/TelegramContext.tsx
@@ -2,13 +2,14 @@
 import { createContext, useContext, useEffect, type ReactNode } from 'react';
 import { telegramService } from '../services/TelegramService';
 import { apiService } from '../services/ApiService';
-import { useUserStore } from '../shared/model';
+import { useUserStore, useStartDataStore } from '../shared/model';
 
 export const TelegramContext = createContext(telegramService);
 
 export function TelegramProvider({ children }: { children: ReactNode }) {
   const setUser = useUserStore((s) => s.setUser);
   const setStartData = useUserStore((s) => s.setStartData);
+  const setStartStoreData = useStartDataStore((s) => s.setStartData);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -39,7 +40,8 @@ export function TelegramProvider({ children }: { children: ReactNode }) {
               payload: webApp.initData,
             })
             .then((res) => {
-              setStartData(res.data);
+              setStartData(res.data.data);
+              setStartStoreData(res.data.data);
             })
             .catch((err) => {
               console.error('start error', err);
@@ -49,7 +51,7 @@ export function TelegramProvider({ children }: { children: ReactNode }) {
     }, 100);
 
     return () => clearInterval(interval);
-  }, [setUser, setStartData]);
+  }, [setUser, setStartData, setStartStoreData]);
 
   return <TelegramContext.Provider value={telegramService}>{children}</TelegramContext.Provider>;
 }

--- a/src/shared/model/__tests__/startDataStore.test.ts
+++ b/src/shared/model/__tests__/startDataStore.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useStartDataStore } from '../startDataStore';
+import type { StartResponse } from '@/types';
+
+const sampleData: StartResponse['data'] = {
+  game_day: 2,
+  coupons: ['c1'],
+  games: [{ id: 1, type: 1, name: 'Game', cost: 1, max_points: 5 }],
+  prizes: [
+    { name: 'Prize', description: null, points: 10 },
+  ],
+  user: {
+    coins: 0,
+    points: 0,
+    new_coupons: [],
+    activated_coupons: [],
+    prizes: [],
+    tg_referral_link: '',
+    this_period_activated_coupons: [],
+    this_period_new_coupons: [],
+  },
+  user_can_play: { 1: true },
+};
+
+describe('useStartDataStore', () => {
+  beforeEach(() => {
+    useStartDataStore.getState().reset();
+  });
+
+  it('saves start data fields', () => {
+    useStartDataStore.getState().setStartData(sampleData);
+    const state = useStartDataStore.getState();
+    expect(state.gameDay).toBe(2);
+    expect(state.coupons).toEqual(['c1']);
+    expect(state.games).toEqual(sampleData.games);
+    expect(state.prizes).toEqual(sampleData.prizes);
+    expect(state.userCanPlay).toEqual({ 1: true });
+  });
+});

--- a/src/shared/model/__tests__/userStore.test.ts
+++ b/src/shared/model/__tests__/userStore.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUserStore } from '../userStore';
+import type { StartResponse } from '@/types';
+
+const sampleData: StartResponse['data'] = {
+  game_day: 1,
+  coupons: [],
+  games: [],
+  prizes: [],
+  user: {
+    coins: 5,
+    points: 10,
+    new_coupons: [],
+    activated_coupons: [],
+    prizes: [],
+    tg_referral_link: '',
+    this_period_activated_coupons: [],
+    this_period_new_coupons: [],
+  },
+  user_can_play: {},
+};
+
+describe('useUserStore', () => {
+  beforeEach(() => {
+    useUserStore.getState().reset();
+  });
+
+  it('stores coins and points from start data', () => {
+    useUserStore.getState().setStartData(sampleData);
+    const state = useUserStore.getState();
+    expect(state.coins).toBe(5);
+    expect(state.points).toBe(10);
+    expect(state.startData).toEqual(sampleData);
+  });
+});

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -2,3 +2,4 @@ export * from './userStore';
 export * from './checkStore';
 export * from './uiStore';
 export * from './modalStore';
+export * from './startDataStore';

--- a/src/shared/model/startDataStore.ts
+++ b/src/shared/model/startDataStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import type { StartResponse } from '@/types';
+
+interface StartDataState {
+  gameDay: number | null;
+  coupons: unknown[];
+  games: StartResponse['data']['games'];
+  prizes: StartResponse['data']['prizes'];
+  userCanPlay: StartResponse['data']['user_can_play'];
+  setStartData: (data: StartResponse['data']) => void;
+  reset: () => void;
+}
+
+export const useStartDataStore = create<StartDataState>((set) => ({
+  gameDay: null,
+  coupons: [],
+  games: [],
+  prizes: [],
+  userCanPlay: {},
+  setStartData: (data) =>
+    set({
+      gameDay: data.game_day,
+      coupons: data.coupons,
+      games: data.games,
+      prizes: data.prizes,
+      userCanPlay: data.user_can_play,
+    }),
+  reset: () =>
+    set({ gameDay: null, coupons: [], games: [], prizes: [], userCanPlay: {} }),
+}));

--- a/src/shared/model/userStore.ts
+++ b/src/shared/model/userStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { StartResponse } from '@/types';
 
 interface User {
   id: number;
@@ -11,22 +12,31 @@ interface User {
 interface UserStore {
   user: User | null;
   coins: number;
+  points: number;
   /**
    * Data returned from `/api/start` endpoint.
    */
-  startData: unknown | null;
+  startData: StartResponse['data'] | null;
   setUser: (user: User) => void;
-  setStartData: (data: unknown) => void;
+  setStartData: (data: StartResponse['data']) => void;
   addCoins: (amount: number) => void;
+  addPoints: (amount: number) => void;
   reset: () => void;
 }
 
 export const useUserStore = create<UserStore>((set) => ({
   user: null,
   coins: 0,
+  points: 0,
   startData: null,
   setUser: (user) => set({ user }),
-  setStartData: (data) => set({ startData: data }),
+  setStartData: (data) =>
+    set({
+      startData: data,
+      coins: data.user.coins,
+      points: data.user.points,
+    }),
   addCoins: (amount) => set((state) => ({ coins: state.coins + amount })),
-  reset: () => set({ user: null, coins: 0, startData: null }),
+  addPoints: (amount) => set((state) => ({ points: state.points + amount })),
+  reset: () => set({ user: null, coins: 0, points: 0, startData: null }),
 }));


### PR DESCRIPTION
## Summary
- create `startDataStore` for API start response
- extend `userStore` with points and typed start response
- update `TelegramContext` to store start response in user and start stores
- export new store
- add unit tests for the stores

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5a4921688323baa49ab540291d72