### PR TITLE
Implement start game request on how to play modal

### DIFF
--- a/src/features/game/lib/renderHowToPlayModal.tsx
+++ b/src/features/game/lib/renderHowToPlayModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useModalStore } from '@/shared/model/modalStore';
 import { ZewaButton, Text } from '@/shared/ui';
 import { Flex } from 'antd';
@@ -11,39 +12,68 @@ export const renderHowToPlayModal = () => {
   const startGame = useGameModelStore.getState().startGame;
   const { openModal, closeModal } = useModalStore.getState();
 
-  const handleStart = () => {
-    setHasPlayedEver(true);
-    setHasPlayedSession(true);
-    closeModal();
+  const ModalContent = () => {
+    const [loading, setLoading] = useState(true);
 
-    // 🔜 В будущем: запуск онбординга
-    startOnboarding();
-  };
+    useEffect(() => {
+      let active = true;
+      fetch('/api/game/start')
+        .then((res) => res.json())
+        .then((data) => {
+          if (!active) return;
+          console.log(data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          if (!active) return;
+          console.error(err);
+          setLoading(false);
+        });
+      return () => {
+        active = false;
+      };
+    }, []);
 
-  const handleSkip = () => {
-    setHasPlayedEver(true);
-    setHasPlayedSession(true);
-    startGame();
-    closeModal();
-  };
+    const handleStart = () => {
+      setHasPlayedEver(true);
+      setHasPlayedSession(true);
+      closeModal();
 
-  openModal({
-    title: 'Как играть?',
-    closable: false,
-    content: (
+      // 🔜 В будущем: запуск онбординга
+      startOnboarding();
+    };
+
+    const handleSkip = () => {
+      setHasPlayedEver(true);
+      setHasPlayedSession(true);
+      startGame();
+      closeModal();
+    };
+
+    return (
       <Flex vertical gap="20px">
         <Text size="p4" align="center" color="#596471">
           Добро пожаловать! Сейчас подробнее расскажем, как играть.
         </Text>
         <Flex vertical gap="10px">
-          <ZewaButton variant="blue-b" onClick={handleStart}>
-            Начать
-          </ZewaButton>
-          <ZewaButton variant="blue-b" onClick={handleSkip}>
-            Пропустить
-          </ZewaButton>
+          {!loading && (
+            <ZewaButton variant="blue-b" onClick={handleStart}>
+              Начать
+            </ZewaButton>
+          )}
+          {!loading && (
+            <ZewaButton variant="blue-b" onClick={handleSkip}>
+              Пропустить
+            </ZewaButton>
+          )}
         </Flex>
       </Flex>
-    ),
+    );
+  };
+
+  openModal({
+    title: 'Как играть?',
+    closable: false,
+    content: <ModalContent />,
   });
 };


### PR DESCRIPTION
## Summary
- send request to `/api/game/start` when the how-to-play modal appears
- hide start/skip buttons until the server responds
- log response data to console

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e2644c5483238ab41462686ad644