### PR TITLE
Add history mock checks

### DIFF
--- a/src/features/history/HistoryScreen.tsx
+++ b/src/features/history/HistoryScreen.tsx
@@ -3,6 +3,7 @@ import { PageContainer, Text } from '@/shared/ui';
 import { useUserStore } from '@/shared/model';
 import { apiService } from '@/services';
 import * as S from '../tournament/TournamentScreen.styles';
+import { mockChecks } from './mocks';
 
 interface HistoryCheck {
   date_time_raw: string;
@@ -33,7 +34,7 @@ export function HistoryScreen() {
       .then((res) => {
         const { data } = res.data ?? [];
         console.info(data);
-        setChecks(data?.checks);
+        setChecks(data?.checks?.length ? data.checks : mockChecks);
         setGames(data?.games);
       })
       .catch((err) => {

--- a/src/features/history/mocks.ts
+++ b/src/features/history/mocks.ts
@@ -1,0 +1,23 @@
+export interface HistoryCheck {
+  date_time_raw: string;
+  coins_earned: number;
+  status: string;
+}
+
+export const mockChecks: HistoryCheck[] = [
+  {
+    date_time_raw: '2024-05-01 10:30',
+    coins_earned: 10,
+    status: 'Засчитан',
+  },
+  {
+    date_time_raw: '2024-05-02 09:15',
+    coins_earned: 0,
+    status: 'Отклонён',
+  },
+  {
+    date_time_raw: '2024-05-03 17:45',
+    coins_earned: 5,
+    status: 'Засчитан',
+  },
+];


### PR DESCRIPTION
## Summary
- add mock history check data
- import mock data in history screen and use when API returns an empty array

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f81a2608883239d81f2c6643ad8ad