### PR TITLE
Implement onboarding persistence

### DIFF
--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -5,6 +5,8 @@ import {
   BackpackContainer,
   Navigation,
 } from './HomeScreen.styles';
+import { useEffect, useState } from 'react';
+import { OnboardingScreen } from '../onboarding';
 import { PlayIcon, ScanIcon, TournamentIcon, UserIcon, ZewaButton } from '@/shared/ui';
 import { renderQrScannerModal } from '@/features';
 import { useNavigate } from 'react-router-dom';
@@ -12,10 +14,31 @@ import { Flex } from 'antd';
 import PrizesScale from '../prizes-scale';
 import { Coins } from '../coins/Coins';
 
+const ONBOARDING_KEY = 'home_onboarding_viewed';
+
 export function HomeScreen() {
   const navigate = useNavigate();
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
-  return (
+  useEffect(() => {
+    try {
+      const viewed = window.localStorage.getItem(ONBOARDING_KEY);
+      setShowOnboarding(!viewed);
+    } catch {
+      setShowOnboarding(false);
+    }
+  }, []);
+
+  const handleFinishOnboarding = () => {
+    try {
+      window.localStorage.setItem(ONBOARDING_KEY, 'true');
+    } catch {}
+    setShowOnboarding(false);
+  };
+
+  return showOnboarding ? (
+    <OnboardingScreen onFinish={handleFinishOnboarding} />
+  ) : (
     <HomeWrapper>
       <Navigation>
         <Flex justify="space-between">


### PR DESCRIPTION
## Summary
- show onboarding screen on the home page only for first-time users

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f9cd45bd88323b491ab821beb4ed9