### PR TITLE
Fix modal reopen after exiting game

### DIFF
--- a/src/features/game/lib/useHowToPlayEntry.tsx
+++ b/src/features/game/lib/useHowToPlayEntry.tsx
@@ -28,10 +28,12 @@ export function useHowToPlayEntry(navigate: NavigateFunction) {
   }, [resetGame, resetSession]);
 
   useEffect(() => {
+    let isMounted = true;
     if (hasHydrated && !hasPlayedSession && user) {
       apiService
         .gameStart({ game: game_id })
         .then((res) => {
+          if (!isMounted) return;
           if (res.data) {
             if (res.data.success) {
               const { game_coins, user_can_play } = res.data.data;
@@ -71,6 +73,7 @@ export function useHowToPlayEntry(navigate: NavigateFunction) {
           }
         })
         .catch((err) => {
+          if (!isMounted) return;
           console.error('gameStart error', err);
           openModal({
             title: 'Упс!',
@@ -86,5 +89,9 @@ export function useHowToPlayEntry(navigate: NavigateFunction) {
           });
         });
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [hasHydrated, hasPlayedEver, hasPlayedSession, navigate, openModal, setAvailableCoins, user]);
 }


### PR DESCRIPTION
## Summary
- prevent game start modal from opening after leaving the game

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68831ea26de08323ac1d5337253073d1