### PR TITLE
Fix game reset logic

### DIFF
--- a/src/features/game/lib/hooks/useGameTicker.ts
+++ b/src/features/game/lib/hooks/useGameTicker.ts
@@ -17,6 +17,12 @@ export const useGameTicker = (canvasWidth: number, canvasHeight: number) => {
   const ADD_INTERVAL = 1600;
 
   useEffect(() => {
+    if (!isGameStarted) {
+      timer.current = 0;
+    }
+  }, [isGameStarted]);
+
+  useEffect(() => {
     const handleVisibility = () => {
       if (document.hidden) pauseGame();
       else resumeGame();

--- a/src/features/game/model/coinAnimationStore.ts
+++ b/src/features/game/model/coinAnimationStore.ts
@@ -10,6 +10,7 @@ interface CoinAnimationState {
   flyingCoins: FlyingCoin[];
   launchCoin: (from: { x: number; y: number }, to: { x: number; y: number }) => void;
   removeCoin: (id: string) => void;
+  reset: () => void;
 }
 
 export const useCoinAnimationStore = create<CoinAnimationState>((set) => ({
@@ -25,4 +26,5 @@ export const useCoinAnimationStore = create<CoinAnimationState>((set) => ({
     set((s) => ({
       flyingCoins: s.flyingCoins.filter((c) => c.id !== id),
     })),
+  reset: () => set({ flyingCoins: [] }),
 }));

--- a/src/features/game/model/gameModelStore.ts
+++ b/src/features/game/model/gameModelStore.ts
@@ -15,6 +15,8 @@ export interface Item {
 import { handleItemCatch } from './itemLogic';
 import { BACKPACK_HEIGHT, BACKPACK_WIDTH } from './backpack';
 import { useGameProgressStore } from './useGameProgressStore';
+import { useOnboardingStore } from './onboardingStore';
+import { useCoinAnimationStore } from './coinAnimationStore';
 
 export type SpecialItemKind = 'coin';
 
@@ -187,6 +189,8 @@ export const useGameModelStore = create<GameModelState>((set, get) => ({
   resetGame: () => {
     get().resetItems();
     get().resetBackpack();
+    useOnboardingStore.getState().reset();
+    useCoinAnimationStore.getState().reset();
     useGameProgressStore.getState().resetSession();
     sessionStorage.removeItem('cameFromRules');
     set(() => ({


### PR DESCRIPTION
## Summary
- clear flying coins and onboarding state when restarting
- reset spawn timer when game is not running

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883208bd71c83238a8148b6e6fb8bbe