### PR TITLE
Implement telegram QR scanning

### DIFF
--- a/src/hooks/useReceiptScan.tsx
+++ b/src/hooks/useReceiptScan.tsx
@@ -143,7 +143,28 @@ export function useReceiptScan() {
     const opened = telegramService.showScanQrPopup();
     if (!opened) {
       renderScanErrorModal('Не удалось открыть сканер. Попробуйте ввести чек вручную.');
+      return;
     }
+
+    const handleQr = (code: string) => {
+      cleanup();
+      sendReceipt(code);
+    };
+
+    const handleError = () => {
+      cleanup();
+      renderScanErrorModal('Ошибка при сканировании QR-кода. Попробуйте ещё раз или введите чек вручную.');
+    };
+
+    const cleanup = () => {
+      telegramService.offEvent('qrCodeReceived', handleQr);
+      telegramService.offEvent('scanQrPopupClosed', cleanup);
+      telegramService.offEvent('onScanError', handleError);
+    };
+
+    telegramService.onEvent('qrCodeReceived', handleQr);
+    telegramService.onEvent('onScanError', handleError);
+    telegramService.onEvent('scanQrPopupClosed', cleanup);
   };
 
   return {


### PR DESCRIPTION
## Summary
- extend `openTelegramScanner` to scan QR codes directly in Telegram

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cf20afc0832393cbdc8a8b8973cb