### PR TITLE
fix pause resume logic

### DIFF
--- a/src/features/game/lib/hooks/__tests__/useGameTicker.test.tsx
+++ b/src/features/game/lib/hooks/__tests__/useGameTicker.test.tsx
@@ -56,4 +56,16 @@ describe('useGameTicker', () => {
     document.dispatchEvent(new Event('visibilitychange'));
     expect(resumeGame).toHaveBeenCalled();
   });
+
+  it('does not resume when already paused', () => {
+    useGameModelStore.setState({ isPaused: true });
+    renderHook(() => useGameTicker(100, 200));
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(resumeGame).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event('focus'));
+    expect(resumeGame).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/game/lib/hooks/useGameTicker.ts
+++ b/src/features/game/lib/hooks/useGameTicker.ts
@@ -24,11 +24,18 @@ export const useGameTicker = (canvasWidth: number, canvasHeight: number) => {
 
   useEffect(() => {
     const handleVisibility = () => {
-      if (document.hidden) pauseGame();
-      else resumeGame();
+      if (document.hidden) {
+        pauseGame();
+      } else if (!useGameModelStore.getState().isPaused) {
+        resumeGame();
+      }
     };
     const handleBlur = () => pauseGame();
-    const handleFocus = () => resumeGame();
+    const handleFocus = () => {
+      if (!useGameModelStore.getState().isPaused) {
+        resumeGame();
+      }
+    };
 
     document.addEventListener('visibilitychange', handleVisibility);
     window.addEventListener('blur', handleBlur);


### PR DESCRIPTION
## Summary
- refine focus/visibility handlers to not automatically resume when paused
- test that game does not resume automatically if it was paused

## Testing
- `npx vitest run` *(fails: parseReceipt, GameRestart, GameScreen, userStore, GameCanvas)*

------
https://chatgpt.com/codex/tasks/task_e_688c74a1c5b88323903f46b16376df33