### PR TITLE
Add receipt modal in manual form

### DIFF
--- a/src/features/checks/manual-input-form/useManualInputForm.tsx
+++ b/src/features/checks/manual-input-form/useManualInputForm.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react';
 import { Text, Spinner } from '@vkontakte/vkui';
 import { useModalStore } from '@/shared/model/modalStore';
+import { showModal } from '../lib/showModal';
 import { apiService, telegramService } from '@/services';
 import {
   ManualInputFormState,
@@ -83,22 +84,18 @@ export function useManualInputForm() {
         date: formattedDate,
       });
 
-      openModal({
-        title: 'Проверка чека',
-        closable: true,
-        content: (
-          <Text>
-            {resp.data.message ??
-              'После проверки мы зарегистрируем чек, начислим вам монеты и пришлем уведомление об этом.'}
-          </Text>
-        ),
-      });
+      showModal(
+        'Проверка чека',
+        resp.data.message ??
+          'После проверки мы зарегистрируем чек, начислим вам монеты и пришлём уведомление об этом.',
+        true,
+      );
     } catch {
-      openModal({
-        title: 'Ошибка',
-        closable: true,
-        content: <Text>Сеть недоступна или сервер не отвечает</Text>,
-      });
+      showModal(
+        'Упс!',
+        'что-то пошло не так. Попробуй повторить позже',
+        true,
+      );
     } finally {
       setPending(false);
     }


### PR DESCRIPTION
## Summary
- show success modal with `showModal` when manually sending a check
- handle request errors with a generic error modal

## Testing
- `npm test` *(fails: missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_688c7e7173a88323a839ebfcf6e7e73e